### PR TITLE
Implement three new actions for fetching affiliations, clinic areas, and assessment items

### DIFF
--- a/lib/guest_request/src/main.js
+++ b/lib/guest_request/src/main.js
@@ -1,37 +1,50 @@
 import { Client, Databases } from 'node-appwrite';
 
 /**
- * Appwrite function to retrieve documents that don't require authentication.
- * And may add other actions in the future.
- * @param {object} res - Response object used to send the JSON response.
- * @returns {Promise<void>}
+ * Serverless function handler to retrieve different types of documents from the Appwrite database which don't require authentication.
+ * 
+ * Supported actions:
+ * - 'getAffiliations': Fetches affiliation documents.
+ * - 'getClinicAreas': Fetches clinic area documents.
+ * - 'getAssessmentItems': Fetches assessment item documents.
+ * 
+ * @param {Object} context - The context object containing the HTTP request and response.
+ * @param {Object} context.req - The HTTP request object.
+ * @param {Object} context.res - The HTTP response object.
+ * 
+ * @returns {Promise<void>} Returns a JSON response based on the requested action.
  */
-export default async ({ res }) => {
-  /**
-   * Initialize Appwrite client (project-scoped, no authentication).
-   */
+export default async ({ req, res }) => {
+  const { action } = JSON.parse(req.body || '{}');
+
   const client = new Client()
     .setEndpoint(process.env.APPWRITE_ENDPOINT)
     .setProject(process.env.PROJECT_ID);
 
   const databases = new Databases(client);
-
   const databaseId = process.env.DB_ID;
-  const collectionId = process.env.AFFILIATIONS_ID;
 
   try {
-    /**
-     * Fetch all documents from the affiliations collection.
-     */
-    const result = await databases.listDocuments(databaseId, collectionId);
+    if (action === 'getAffiliations') {
+      const result = await databases.listDocuments(databaseId, process.env.AFFILIATIONS_ID);
+      return res.json({ affiliations: result.documents });
+    }
 
-    return res.json({
-      affiliations: result.documents
-    });
+    if (action === 'getClinicAreas') {
+      const result = await databases.listDocuments(databaseId, process.env.CLINIC_AREA_ID);
+      return res.json({ clinicAreas: result.documents });
+    }
+
+    if (action === 'getAssessmentItems') {
+      const result = await databases.listDocuments(databaseId, process.env.ASSESSMENT_ITEMS_ID);
+      return res.json({ standardItems: result.documents });
+    }
+
+    return res.json({ status: "error", message: "Unknown action" });
   } catch (err) {
-    console.error("❌ Failed to fetch affiliations:", err);
+    console.error("❌ Failed to fetch data:", err);
     return res.json(
-      { error: "Unable to fetch affiliations" },
+      { error: "Unable to fetch data" },
       500
     );
   }


### PR DESCRIPTION
## Summary
Added three new actions to the serverless function to support fetching affiliations, clinic areas, and assessment items from the Appwrite database.

## Changes
- Implemented `getAffiliations` action to retrieve affiliation documents.
- Implemented `getClinicAreas` action to retrieve clinic area documents.
- Implemented `getAssessmentItems` action to retrieve assessment item documents.
- Set up unified error handling and structured JSON responses.

## Motivation
Expanding the backend functionality to allow dynamic retrieval of key datasets required for the project, improving flexibility and supporting future frontend integration.

## Notes
- Environment variables are used to configure database and collection IDs.
- Each action returns the full list of documents from the corresponding collection.
- Safe to merge after basic testing.
